### PR TITLE
Update package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,15 @@
         "@types/tough-cookie": "2.3.2"
       }
     },
+    "@types/request-promise-native": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.14.tgz",
+      "integrity": "sha512-m6PNeopPU75gjN3+dD9AeWwm7h2QIOuLnmn143+Qs0bMYFyri9/bhCgikHlgzH0gk7xR48nef82GWeRV6N3DxA==",
+      "dev": true,
+      "requires": {
+        "@types/request": "2.47.0"
+      }
+    },
     "@types/tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.2.tgz",


### PR DESCRIPTION
When you run 'npm i', it forces to update a package-lock.json file. It seems to me, that the types/request-promise-native package is missed from the file.