### PR TITLE
Fix some issues

### DIFF
--- a/src/services/kucoin/constants.ts
+++ b/src/services/kucoin/constants.ts
@@ -1,3 +1,5 @@
-export const KUCOIN_SERVER_PRODUCTION_URI = 'https://api.kucoin.com';
-export const KUCOIN_RECENTLY_DEAL_ORDERS_URI = '/v1/open/deal-orders';
-export const KUCOIN_ORDER_BOOKS_URI = '/v1/open/orders';
+export const KuCoinConstants = {
+    KuCoinServerProductionUrl: 'https://api.kucoin.com',
+    KuCoinRecentlyDealOrdersUri: '/v1/open/deal-orders',
+    KuCoinOrderBooksUri: '/v1/open/orders'
+}

--- a/src/services/kucoin/constants.ts
+++ b/src/services/kucoin/constants.ts
@@ -1,5 +1,7 @@
-export const KuCoinConstants = {
-    KuCoinServerProductionUrl: 'https://api.kucoin.com',
-    KuCoinRecentlyDealOrdersUri: '/v1/open/deal-orders',
-    KuCoinOrderBooksUri: '/v1/open/orders'
-}
+const constants = {
+    serverProductionUrl: 'https://api.kucoin.com',
+    recentlyDealOrdersUri: '/v1/open/deal-orders',
+    orderBooksUri: '/v1/open/orders'
+};
+
+export const KuCoinConstants: Readonly<typeof constants> =  constants;

--- a/src/services/kucoin/kucoin-response-parser.ts
+++ b/src/services/kucoin/kucoin-response-parser.ts
@@ -1,18 +1,18 @@
 import { isArray, isNumber, isString } from 'util';
 import { Order, OrderType, CurrencyPair, OrderBook } from '../../core';
 
-type orderResponseResult = [
+type OrderResponseResult = [
     /*Price*/ number,
     /*Amount*/ number,
     /*Volume*/ number
 ];
 
-type orderBookResponseResult = {
-    'SELL': orderResponseResult[],
-    'BUY': orderResponseResult[]
+type OrderBookResponseResult = {
+    'SELL': OrderResponseResult[],
+    'BUY': OrderResponseResult[]
 };
 
-type dealOrderResponseResult = [
+type DealOrderResponseResult = [
     /*Timestamp*/ number,
     /*Order Type*/ string,
     /*Price*/ number,
@@ -21,28 +21,28 @@ type dealOrderResponseResult = [
 ];
 
 const Guards = {
-    dataObjOwnerGuard: (dataOwner: any): dataOwner is { data: any } => dataOwner && dataOwner.data,
-    dataArrayOwnerGuard: (dataOwner: any): dataOwner is { data: any[] } => Guards.dataObjOwnerGuard(dataOwner) && isArray(dataOwner.data),
-    orderBookGuard: (orderBook: any): orderBook is orderBookResponseResult => {
+    isDataObjOwner: (dataOwner: any): dataOwner is { data: any } => dataOwner && dataOwner.data,
+    isDataArrayOwner: (dataOwner: any): dataOwner is { data: any[] } => Guards.isDataObjOwner(dataOwner) && isArray(dataOwner.data),
+    isOrderBook: (orderBook: any): orderBook is OrderBookResponseResult => {
         return orderBook && orderBook['SELL'] && orderBook['BUY']
             && isArray(orderBook['SELL']) && isArray(orderBook['BUY'])
-            && orderBook['SELL'].every((order: any) => Guards.orderGuard(order))
-            && orderBook['BUY'].every((order: any) => Guards.orderGuard(order));
+            && orderBook['SELL'].every((order: any) => Guards.isOrder(order))
+            && orderBook['BUY'].every((order: any) => Guards.isOrder(order));
     },
-    orderGuard: (order: any): order is orderResponseResult => {
+    isOrder: (order: any): order is OrderResponseResult => {
         return order && isNumber(order[0]) && isNumber(order[1]) && isNumber(order[2]);
     },
-    dealOrderGuard: (dealOrder: any): dealOrder is dealOrderResponseResult => {
+    isDealOrder: (dealOrder: any): dealOrder is DealOrderResponseResult => {
         return dealOrder && isNumber(dealOrder[0]) && isString(dealOrder[1])
             && isNumber(dealOrder[2]) && isNumber(dealOrder[3]) && isNumber(dealOrder[4]);
     },
-    orderTypeGuard: (orderType: string): orderType is 'SELL' | 'BUY' => orderType === 'SELL' || orderType === 'BUY'
+    isOrderType: (orderType: string): orderType is 'SELL' | 'BUY' => orderType === 'SELL' || orderType === 'BUY'
 };
 
 export class KuCoinResponseParser {
     parseOrderBook(currencyPair: CurrencyPair, responseResult: string): OrderBook {
         const obj = JSON.parse(responseResult);
-        if (!Guards.dataObjOwnerGuard(obj) || !Guards.orderBookGuard(obj.data))
+        if (!Guards.isDataObjOwner(obj) || !Guards.isOrderBook(obj.data))
             throw new Error(`The result ${responseResult} isn't the order book type.`);
         const orderBookResponseResult = obj.data;
         return {
@@ -69,13 +69,13 @@ export class KuCoinResponseParser {
 
     parseDealOrders(currencyPair: CurrencyPair, responseResult: string): Order[] {
         const obj = JSON.parse(responseResult);
-        if (!Guards.dataArrayOwnerGuard(obj))
+        if (!Guards.isDataArrayOwner(obj))
             throw new Error(`The result ${responseResult} isn't the orders type.`);
 
         return obj.data.map<Order>(orderObj => {
-            if (!Guards.dealOrderGuard(orderObj))
+            if (!Guards.isDealOrder(orderObj))
                 throw new Error(`The element (${orderObj}) of the orders object isn't the deal order type.`);
-            if (!Guards.orderTypeGuard(orderObj[1]))
+            if (!Guards.isOrderType(orderObj[1]))
                 throw new Error(`The type of the order (${orderObj}) is incorrect. It should be 'SELL' or 'BUY' value.`);
 
             return {

--- a/src/services/kucoin/kucoin-service.ts
+++ b/src/services/kucoin/kucoin-service.ts
@@ -2,17 +2,13 @@ import * as request from 'request-promise-native';
 import { ExchangeService, Order, OrderInfo, OrderBook, CurrencyPair, OrderType } from '../../core';
 import { RepeatPromise } from '../../utils';
 import { KuCoinResponseParser } from './kucoin-response-parser';
-import {
-    KUCOIN_SERVER_PRODUCTION_URI,
-    KUCOIN_RECENTLY_DEAL_ORDERS_URI,
-    KUCOIN_ORDER_BOOKS_URI
-} from './constants';
+import { KuCoinConstants } from './constants';
 
 export class KuCoinService implements ExchangeService {
     private _kuCoinResponseParser: KuCoinResponseParser = new KuCoinResponseParser();
     private _requestTryCount: number;
 
-    constructor(public readonly serverUri: string = KUCOIN_SERVER_PRODUCTION_URI, requestTryCount: number = 3) {
+    constructor(public readonly serverUri: string = KuCoinConstants.KuCoinServerProductionUrl, requestTryCount: number = 3) {
         this._requestTryCount = requestTryCount;
     }
 
@@ -34,7 +30,7 @@ export class KuCoinService implements ExchangeService {
 
     async getOrderBook(pair: CurrencyPair, maxLimit?: number): Promise<OrderBook> {
         return new RepeatPromise<OrderBook>((resolve, reject) => {
-            request(KUCOIN_ORDER_BOOKS_URI, {
+            request.get(KuCoinConstants.KuCoinOrderBooksUri, {
                 baseUrl: this.serverUri,
                 method: 'GET',
                 qs: {
@@ -49,7 +45,7 @@ export class KuCoinService implements ExchangeService {
 
     async getRecentDealOrders(pair: CurrencyPair, maxLimit?: number): Promise<Order[]> {
         return new RepeatPromise<Order[]>((resolve, reject) => {
-            request(KUCOIN_RECENTLY_DEAL_ORDERS_URI, {
+            request.get(KuCoinConstants.KuCoinRecentlyDealOrdersUri, {
                 baseUrl: this.serverUri,
                 method: 'GET',
                 qs: {

--- a/src/services/kucoin/kucoin-service.ts
+++ b/src/services/kucoin/kucoin-service.ts
@@ -8,7 +8,7 @@ export class KuCoinService implements ExchangeService {
     private _kuCoinResponseParser: KuCoinResponseParser = new KuCoinResponseParser();
     private _requestTryCount: number;
 
-    constructor(public readonly serverUri: string = KuCoinConstants.KuCoinServerProductionUrl, requestTryCount: number = 3) {
+    constructor(public readonly serverUri: string = KuCoinConstants.serverProductionUrl, requestTryCount: number = 3) {
         this._requestTryCount = requestTryCount;
     }
 
@@ -30,7 +30,7 @@ export class KuCoinService implements ExchangeService {
 
     async getOrderBook(pair: CurrencyPair, maxLimit?: number): Promise<OrderBook> {
         return new RepeatPromise<OrderBook>((resolve, reject) => {
-            request.get(KuCoinConstants.KuCoinOrderBooksUri, {
+            request.get(KuCoinConstants.orderBooksUri, {
                 baseUrl: this.serverUri,
                 method: 'GET',
                 qs: {
@@ -45,7 +45,7 @@ export class KuCoinService implements ExchangeService {
 
     async getRecentDealOrders(pair: CurrencyPair, maxLimit?: number): Promise<Order[]> {
         return new RepeatPromise<Order[]>((resolve, reject) => {
-            request.get(KuCoinConstants.KuCoinRecentlyDealOrdersUri, {
+            request.get(KuCoinConstants.recentlyDealOrdersUri, {
                 baseUrl: this.serverUri,
                 method: 'GET',
                 qs: {

--- a/tests/services/kucoin/kucoin-service.spec.ts
+++ b/tests/services/kucoin/kucoin-service.spec.ts
@@ -17,8 +17,8 @@ describe('KuCoin Exchange Service', () => {
         const currentCase = recentDealOrdersData[0];
         const currencyPair: CurrencyPair = ['AAA', 'BBB'];
 
-        nock(KuCoinConstants.KuCoinServerProductionUrl)
-            .get(KuCoinConstants.KuCoinRecentlyDealOrdersUri)
+        nock(KuCoinConstants.serverProductionUrl)
+            .get(KuCoinConstants.recentlyDealOrdersUri)
             .query({
                 symbol: `${currencyPair[0]}-${currencyPair[1]}`
             })
@@ -49,14 +49,14 @@ describe('KuCoin Exchange Service', () => {
         const currentCase = recentDealOrdersData[0];
         const currencyPair: CurrencyPair = ['AAA', 'BBB'];
 
-        nock(KuCoinConstants.KuCoinServerProductionUrl)
-            .get(KuCoinConstants.KuCoinRecentlyDealOrdersUri)
+        nock(KuCoinConstants.serverProductionUrl)
+            .get(KuCoinConstants.recentlyDealOrdersUri)
             .query({
                 symbol: `${currencyPair[0]}-${currencyPair[1]}`
             })
             .replyWithError('An connection error from the test');
-        nock(KuCoinConstants.KuCoinServerProductionUrl)
-            .get(KuCoinConstants.KuCoinRecentlyDealOrdersUri)
+        nock(KuCoinConstants.serverProductionUrl)
+            .get(KuCoinConstants.recentlyDealOrdersUri)
             .query({
                 symbol: `${currencyPair[0]}-${currencyPair[1]}`
             })
@@ -75,8 +75,8 @@ describe('KuCoin Exchange Service', () => {
         const currentCase = fullOrderBookData[0];
         const currencyPair: CurrencyPair = ['AAA', 'BBB'];
 
-        nock(KuCoinConstants.KuCoinServerProductionUrl)
-            .get(KuCoinConstants.KuCoinOrderBooksUri)
+        nock(KuCoinConstants.serverProductionUrl)
+            .get(KuCoinConstants.orderBooksUri)
             .query({
                 symbol: `${currencyPair[0]}-${currencyPair[1]}`
             })
@@ -118,14 +118,14 @@ describe('KuCoin Exchange Service', () => {
         const currentCase = fullOrderBookData[0];
         const currencyPair: CurrencyPair = ['AAA', 'BBB'];
 
-        nock(KuCoinConstants.KuCoinServerProductionUrl)
-            .get(KuCoinConstants.KuCoinOrderBooksUri)
+        nock(KuCoinConstants.serverProductionUrl)
+            .get(KuCoinConstants.orderBooksUri)
             .query({
                 symbol: `${currencyPair[0]}-${currencyPair[1]}`
             })
             .replyWithError('An connection error from the test');
-        nock(KuCoinConstants.KuCoinServerProductionUrl)
-            .get(KuCoinConstants.KuCoinOrderBooksUri)
+        nock(KuCoinConstants.serverProductionUrl)
+            .get(KuCoinConstants.orderBooksUri)
             .query({
                 symbol: `${currencyPair[0]}-${currencyPair[1]}`
             })

--- a/tests/services/kucoin/kucoin-service.spec.ts
+++ b/tests/services/kucoin/kucoin-service.spec.ts
@@ -2,11 +2,7 @@ import { expect } from 'chai';
 import * as nock from 'nock';
 import { CurrencyPair, Order, OrderType } from '../../../src/core';
 import { KuCoinService } from '../../../src/services/kucoin';
-import {
-    KUCOIN_RECENTLY_DEAL_ORDERS_URI,
-    KUCOIN_SERVER_PRODUCTION_URI,
-    KUCOIN_ORDER_BOOKS_URI
-} from '../../../src/services/kucoin/constants';
+import { KuCoinConstants } from '../../../src/services/kucoin/constants';
 import recentDealOrdersData from './data/recent-deal-orders.data';
 import fullOrderBookData from './data/full-order-book.data';
 
@@ -21,8 +17,8 @@ describe('KuCoin Exchange Service', () => {
         const currentCase = recentDealOrdersData[0];
         const currencyPair: CurrencyPair = ['AAA', 'BBB'];
 
-        nock(KUCOIN_SERVER_PRODUCTION_URI)
-            .get(KUCOIN_RECENTLY_DEAL_ORDERS_URI)
+        nock(KuCoinConstants.KuCoinServerProductionUrl)
+            .get(KuCoinConstants.KuCoinRecentlyDealOrdersUri)
             .query({
                 symbol: `${currencyPair[0]}-${currencyPair[1]}`
             })
@@ -53,14 +49,14 @@ describe('KuCoin Exchange Service', () => {
         const currentCase = recentDealOrdersData[0];
         const currencyPair: CurrencyPair = ['AAA', 'BBB'];
 
-        nock(KUCOIN_SERVER_PRODUCTION_URI)
-            .get(KUCOIN_RECENTLY_DEAL_ORDERS_URI)
+        nock(KuCoinConstants.KuCoinServerProductionUrl)
+            .get(KuCoinConstants.KuCoinRecentlyDealOrdersUri)
             .query({
                 symbol: `${currencyPair[0]}-${currencyPair[1]}`
             })
             .replyWithError('An connection error from the test');
-        nock(KUCOIN_SERVER_PRODUCTION_URI)
-            .get(KUCOIN_RECENTLY_DEAL_ORDERS_URI)
+        nock(KuCoinConstants.KuCoinServerProductionUrl)
+            .get(KuCoinConstants.KuCoinRecentlyDealOrdersUri)
             .query({
                 symbol: `${currencyPair[0]}-${currencyPair[1]}`
             })
@@ -79,8 +75,8 @@ describe('KuCoin Exchange Service', () => {
         const currentCase = fullOrderBookData[0];
         const currencyPair: CurrencyPair = ['AAA', 'BBB'];
 
-        nock(KUCOIN_SERVER_PRODUCTION_URI)
-            .get(KUCOIN_ORDER_BOOKS_URI)
+        nock(KuCoinConstants.KuCoinServerProductionUrl)
+            .get(KuCoinConstants.KuCoinOrderBooksUri)
             .query({
                 symbol: `${currencyPair[0]}-${currencyPair[1]}`
             })
@@ -122,14 +118,14 @@ describe('KuCoin Exchange Service', () => {
         const currentCase = fullOrderBookData[0];
         const currencyPair: CurrencyPair = ['AAA', 'BBB'];
 
-        nock(KUCOIN_SERVER_PRODUCTION_URI)
-            .get(KUCOIN_ORDER_BOOKS_URI)
+        nock(KuCoinConstants.KuCoinServerProductionUrl)
+            .get(KuCoinConstants.KuCoinOrderBooksUri)
             .query({
                 symbol: `${currencyPair[0]}-${currencyPair[1]}`
             })
             .replyWithError('An connection error from the test');
-        nock(KUCOIN_SERVER_PRODUCTION_URI)
-            .get(KUCOIN_ORDER_BOOKS_URI)
+        nock(KuCoinConstants.KuCoinServerProductionUrl)
+            .get(KuCoinConstants.KuCoinOrderBooksUri)
             .query({
                 symbol: `${currencyPair[0]}-${currencyPair[1]}`
             })


### PR DESCRIPTION
- [x] #31 Export the Kucoin constants as a whole object
- [x] Use PascalCase for the names of these constants;
- [x] #39 Kucoin contstants - Use 'URL' for paths started with 'http' and 'URI' for the other paths
- [x] #40 Kucoin service - Use the 'get' alias for requests
- [x] #43 kucoin-response-parser.ts - Use Pascal case for types names
- [x] #30 The kucoin response parser - rename guard's methods, remove the "Guard" postfix