### PR TITLE
Set "no-unused-variable" rule for tslint. Remove unused imports

### DIFF
--- a/src/services/kucoin/kucoin-service.ts
+++ b/src/services/kucoin/kucoin-service.ts
@@ -1,9 +1,9 @@
 import * as request from 'request-promise-native';
 import {
     AuthenticatedRestExchangeService, CurrencyBalance, CurrencyPair,
-    Order, OrderBook, OrderInfo, OrderType, RestExchangeService
+    Order, OrderBook, OrderInfo, RestExchangeService
 } from '../../core';
-import { Identified, isIdentified, RepeatPromise } from '../../utils';
+import { Identified, RepeatPromise } from '../../utils';
 import { KuCoinConstants } from './constants';
 import { KuCoinResponseParser } from './kucoin-response-parser';
 

--- a/tests/services/kucoin/kucoin-response-parser.spec.ts
+++ b/tests/services/kucoin/kucoin-response-parser.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { CurrencyPair, Order, OrderBook, OrderType } from '../../../src/core';
+import { CurrencyPair } from '../../../src/core';
 import { KuCoinResponseParser } from '../../../src/services/kucoin/kucoin-response-parser';
 import { orderBookCases, tradesCases, wrongOrderBookCases, wrongTradesCases } from './data';
 

--- a/tests/services/kucoin/kucoin-service.spec.ts
+++ b/tests/services/kucoin/kucoin-service.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as nock from 'nock';
-import { CurrencyPair, Order, OrderType } from '../../../src/core';
+import { CurrencyPair } from '../../../src/core';
 import { KuCoinService } from '../../../src/services/kucoin';
 import { KuCoinConstants } from '../../../src/services/kucoin/constants';
 import { orderBookCases, tradesCases } from './data';

--- a/tests/services/yobit/yobit-response-parser.spec.ts
+++ b/tests/services/yobit/yobit-response-parser.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { OrderType } from '../../../src/core';
 import { YobitResponseParser } from '../../../src/services/yobit/yobit-response-parser';
 import { orderBookCases, tradesCases, yobitGeneralError } from './data';
 

--- a/tests/services/yobit/yobit-service.spec.ts
+++ b/tests/services/yobit/yobit-service.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import * as nock from 'nock';
-import { CurrencyPair, OrderType } from '../../../src/core';
 import { YobitService } from '../../../src/services/yobit';
 import { YobitConstants } from '../../../src/services/yobit/constants';
 import { orderBookCases, tradesCases } from './data';

--- a/tslint.json
+++ b/tslint.json
@@ -28,7 +28,8 @@
             true,
             "allow-leading-underscore",
             "allow-pascal-case"
-        ]
+        ],
+        "no-unused-variable": true
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
It fixes #33.
Unfortunately tslint extension does not highlight it. See [this comment](https://github.com/palantir/tslint/issues/3425#issuecomment-340733073).
But now appveyor fails when someone commits unused imports/variables. See [proof](https://ci.appveyor.com/project/maxima-net/crypto-kraken-services/build/%2380).