### PR TITLE
Pass queryString as an ojbect instead a string to the sign method of the KuCoinSignatureMaker class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,12 @@
       "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw==",
       "dev": true
     },
+    "@types/qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-mNhVdZHdtKHMMxbqzNK3RzkBcN1cux3AvuCYGTvjEIQT2uheH3eCAyYsbMbh2Bq8nXkeOWs1kyDiF7geWRFQ4Q==",
+      "dev": true
+    },
     "@types/request": {
       "version": "2.47.0",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.0.tgz",
@@ -3424,9 +3430,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "request": {
       "version": "2.87.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "create-hmac": "^1.1.7",
+    "qs": "^6.5.2",
     "request": "^2.87.0",
     "request-promise-native": "^1.0.5",
     "safe-buffer": "^5.1.2"
@@ -37,6 +38,7 @@
     "@types/chai": "^4.1.2",
     "@types/mocha": "^2.2.48",
     "@types/nock": "^9.1.3",
+    "@types/qs": "^6.5.1",
     "@types/request": "^2.47.0",
     "@types/request-promise-native": "^1.0.14",
     "chai": "^4.1.2",

--- a/src/services/kucoin/kucoin-signature-maker.ts
+++ b/src/services/kucoin/kucoin-signature-maker.ts
@@ -1,11 +1,23 @@
 import createHmac = require('create-hmac');
+import * as qs from 'qs';
 import { Buffer } from 'safe-buffer';
 
 export class KuCoinSignatureMaker {
-    sign(secretKey: string, apiEndpoint: string, queryString: string | undefined, timestamp = Date.now()): string {
+    private readonly _queryStringStringifyOptions: qs.IStringifyOptions = {
+        addQueryPrefix: true
+    };
+
+    get queryStringStringifyOptions() {
+        return this._queryStringStringifyOptions;
+    }
+
+    sign(
+        secretKey: string, apiEndpoint: string, queryString: object | string | undefined, timestamp = Date.now()
+    ): string {
         let stringForSign = `${apiEndpoint}/${timestamp}/`;
         if (queryString)
-            stringForSign += `${queryString}`;
+            stringForSign += typeof queryString === 'string' ?
+                queryString : qs.stringify(queryString, this.queryStringStringifyOptions);
 
         const signatureString = new Buffer(stringForSign).toString('base64');
         return createHmac('sha256', secretKey)

--- a/tests/services/kucoin/kucoin-signature-maker.spec.ts
+++ b/tests/services/kucoin/kucoin-signature-maker.spec.ts
@@ -9,24 +9,26 @@ describe('KuCoin Signature Maker', () => {
         kuCoinSignatureMaker = new KuCoinSignatureMaker();
     });
 
-    it('should be sign correctly', () => {
-        const currentApiInfo = exchangeCredentialsCases[0];
+    it('should sign correctly', () => {
+        const currentCredentials = exchangeCredentialsCases[0];
         const endpoint = '/v1/account/balances';
         const nonce = 1506219855000;
         const queryString = '?limit=15';
         const expectedSignature = '6e5cb82abea3ca77e974af3069bdad91d3a34a09314594d56edb749d7e139adf';
         const expectedSignatureWithQueryString = 'c987bc627ef051f2f09a9c1a386f9aad844decdfd739a1ad7b02d7fec9421476';
 
-        const signature = kuCoinSignatureMaker.sign(currentApiInfo.secret, endpoint, undefined, nonce);
-        const signatureWithQueryString = kuCoinSignatureMaker.sign(currentApiInfo.secret, endpoint, queryString, nonce);
+        const signature = kuCoinSignatureMaker.sign(currentCredentials.secret, endpoint, undefined, nonce);
+        const signatureWithQueryString = kuCoinSignatureMaker.sign(
+            currentCredentials.secret, endpoint, queryString, nonce
+        );
 
-        expect(kuCoinSignatureMaker.sign(currentApiInfo.secret, endpoint, undefined)).to.not.be.empty;
+        expect(kuCoinSignatureMaker.sign(currentCredentials.secret, endpoint, undefined)).to.not.be.empty;
         expect(signature).to.not.eql(signatureWithQueryString);
         expect(signature).to.eql(expectedSignature);
         expect(signatureWithQueryString).to.eql(expectedSignatureWithQueryString);
     });
 
-    it('should be return different signatures when parameters is different', () => {
+    it('should return different signatures when parameters is different', () => {
         const endpoints = ['/v1/user/info', '/v1/account/balances'];
         const nonces = [1515531600000, 1527109200000];
 
@@ -84,5 +86,24 @@ describe('KuCoin Signature Maker', () => {
 
         expect(new Set(signaturesList).size).to.eql(signaturesList.length);
         expect(signatures).to.eql(expectedSignatures);
+    });
+
+    it('should sign with different formats of the querystring correctly', () => {
+        const currentCredentials = exchangeCredentialsCases[0];
+        const endpoint = '/v1/account/active';
+        const nonce = 1506219855000;
+        const queryString = '?symbol=AAA-BBB&limit=15';
+        const queryStringObj = {
+            symbol: 'AAA-BBB',
+            limit: 15
+        };
+        const expectedSignature = '55d13353b23c13e1f38d62e8c49b2d40ea55b5308c5829de971df0e8a9c90fa2';
+
+        const signature1 = kuCoinSignatureMaker.sign(currentCredentials.secret, endpoint, queryString, nonce);
+        const signature2 = kuCoinSignatureMaker.sign(currentCredentials.secret, endpoint, queryStringObj, nonce);
+
+        expect(signature1)
+            .to.eql(signature2)
+            .to.eql(expectedSignature);
     });
 });


### PR DESCRIPTION
Fixes: #84 

I've added the `qs` package to our dependencies for parsing/stringify a query string. This package is already used [by the `request` package](https://github.com/request/request/blob/master/package.json#L45):
https://github.com/CryptoKraken/crypto-kraken-services/blob/cea75fcedee9f1f715acf2e83b85e2c760a81ce7/package-lock.json#L3426-L3430

Even when we'll to migrate from the request to other isomorphic packages ([Axios](https://github.com/axios/axios), [SuperAgent](https://github.com/visionmedia/superagent)) we can continue to use the `qs` package, because the Axios mentions using this package and the SuperAgent [uses it](https://github.com/visionmedia/superagent/blob/master/package.json#L35).