### PR TITLE
Remove deprecated API: use Buffer.from instead new Buffer

### DIFF
--- a/src/services/kucoin/kucoin-signature-maker.ts
+++ b/src/services/kucoin/kucoin-signature-maker.ts
@@ -17,7 +17,7 @@ export class KuCoinSignatureMaker {
             stringForSign += typeof queryString === 'string' ?
                 queryString : qs.stringify(queryString, this.queryStringStringifyOptions);
 
-        const signatureString = new Buffer(stringForSign).toString('base64');
+        const signatureString = Buffer.from(stringForSign).toString('base64');
         return createHmac('sha256', secretKey)
             .update(signatureString)
             .digest('hex');


### PR DESCRIPTION
Nodejs display this message:
> [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.